### PR TITLE
create utils folder and gadtet mode script

### DIFF
--- a/utils/self_assign_ip.sh
+++ b/utils/self_assign_ip.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# PLEASE RUN `setup_usb_gadget.sh` first
+# detect USB gadget interface (starts with enx)
+IFACE=$(ip -o link | awk -F': ' '/enx/ {print $2}' | head -n 1)
+
+PI_IP="10.10.10.2"
+HOST_IP="10.10.10.1"
+
+if [ -n "$IFACE" ]; then
+    echo "[+] Found gadget interface: $IFACE"
+    sudo ip link set "$IFACE" up        # bring it up
+    sudo ip addr flush dev "$IFACE"
+    sudo ip addr add "$HOST_IP/24" dev "$IFACE"
+    echo "[+] Assigned $HOST_IP to $IFACE"
+    echo "[*] Waiting for pi@$PI_IP..."
+
+    for i in {1..10}; do
+        if ping -c1 "$PI_IP" &>/dev/null; then
+            echo "[+] Pi is up. Connect with: ssh pi@$PI_IP"
+            break
+        fi
+        sleep 1
+    done
+else
+    echo "[-] No enx* interface found"
+fi

--- a/utils/setup_usb_gadget.sh
+++ b/utils/setup_usb_gadget.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+# This script can be ran inside the raspberry pi after it is configured
+# `chmod +x setup_usb_gadget.sh`
+# then `./setup_usb_gadget.sh`
+
+echo "[*] Setting up USB gadget mode..."
+
+BOOT_PATH="/boot/firmware"
+CONFIG_TXT="$BOOT_PATH/config.txt"
+CMDLINE_TXT="$BOOT_PATH/cmdline.txt"
+
+# enable dwc2 overlay in config.txt
+# adds the `dtoverlay=dwc2` line to the config.txt file
+if ! grep -q "^dtoverlay=dwc2" "$CONFIG_TXT"; then
+    echo "dtoverlay=dwc2" | sudo tee -a "$CONFIG_TXT"
+    echo "[+] Added dtoverlay=dwc2 to config.txt"
+fi
+
+# add modules-load to cmdline.txt
+if ! grep -q "modules-load=dwc2,g_ether" "$CMDLINE_TXT"; then
+    sudo sed -i 's/\brootwait\b/rootwait modules-load=dwc2,g_ether/' "$CMDLINE_TXT"
+    echo "[+] Inserted modules-load=dwc2,g_ether into cmdline.txt"
+fi
+
+# enable SSH if not enabled yet
+if [ ! -f "$BOOT_PATH/ssh" ]; then
+    sudo touch "$BOOT_PATH/ssh"
+    echo "[+] Enabled SSH"
+fi
+
+# create bring-up-usb0 script
+sudo tee /usr/local/sbin/bring-up-usb0.sh > /dev/null <<EOF
+#!/bin/bash
+ip link set usb0 up
+ip addr add 10.10.10.2/24 dev usb0
+EOF
+sudo chmod +x /usr/local/sbin/bring-up-usb0.sh
+echo "[+] Created /usr/local/sbin/bring-up-usb0.sh"
+
+# create systemd service
+sudo tee /etc/systemd/system/usb0.service > /dev/null <<EOF
+[Unit]
+Description=Manually bring up usb0 interface
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/bring-up-usb0.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl enable usb0.service
+echo "[+] Enabled usb0 systemd service"
+
+echo "All done. Reboot and test with: ssh username@10.10.10.2"


### PR DESCRIPTION
Create utils folder where all helper scripts should live

one-shot setup script that enables USB Ethernet gadget mode on Raspberry Pi Zero/Zero 2 W using minimal system resources. It's designed for headless setups and removes reliance on Wi-Fi or DHCP services.

The script performs the following:

✅ Adds dtoverlay=dwc2 to /boot/firmware/config.txt

✅ Injects modules-load=dwc2,g_ether into /boot/firmware/cmdline.txt

✅ Ensures SSH is enabled on boot by creating the /boot/firmware/ssh marker

✅ Creates a systemd service (usb0.service) that:

Brings up usb0 manually

Assigns a static IP of 10.10.10.2/24 using ip commands

✅ Avoids NetworkManager, DHCP, and Wi-Fi dependencies to minimize startup time and memory usage

This setup is ideal for plug-and-play USB access, including SSH over USB, without additional software or configuration after initial provisioning.